### PR TITLE
feat: load FTP_ENCRYPTION_KEY from OS keychain or global env

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you encounter build issues on Windows:
 | `FTP_PROTOCOL` | Protocol to use: `ftp` or `sftp` | ftp |
 | `FTP_PRIVATE_KEY_PATH` | Path to SSH private key for SFTP (e.g. `~/.ssh/id_ed25519`) | (auto-detect) |
 | `FTP_PASSPHRASE` | Passphrase for the SSH private key (supports encryption) | (empty string) |
-| `FTP_ENCRYPTION_KEY` | 64-character hex AES-256 key for decrypting credentials | (disabled) |
+| `FTP_ENCRYPTION_KEY` | 64-character hex AES-256 key for decrypting credentials — store in OS keychain, not here | (disabled) |
 
 ## SSH / SFTP Support
 
@@ -175,7 +175,9 @@ The server looks for a private key in this order:
 
 ## Credential Encryption
 
-Storing plaintext passwords in your Claude config file is a security risk. The server supports AES-256-GCM encryption for `FTP_USER` and `FTP_PASSWORD` so the config only ever contains ciphertext.
+Storing plaintext passwords in your Claude config file is a security risk. The server supports AES-256-GCM encryption for `FTP_USER`, `FTP_PASSWORD`, and `FTP_PASSPHRASE` so the config only ever contains ciphertext.
+
+The encryption key itself (`FTP_ENCRYPTION_KEY`) must **never** be stored in the same config file as the encrypted credentials — that would defeat the purpose. Store it in the OS keychain, or global environment variable instead (see below).
 
 ### 1. Generate an encryption key
 
@@ -185,18 +187,45 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 Keep this key secret — treat it like a master password.
 
-### 2. Encrypt a credential value
+### 2. Store the key in the OS keychain (recommended)
+
+After building the project, run the one-time setup script:
+
+```bash
+npm run build
+npm run store-key -- <your-64-char-hex-key>
+```
+
+This writes the key into the OS keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service). The server loads it automatically on start-up — no `FTP_ENCRYPTION_KEY` in the config file required.
+
+#### Option B: global environment variable
+
+If you prefer not to use the keychain, export the key from your shell profile (`~/.zshrc`, `~/.bash_profile`, etc.):
+
+```bash
+export FTP_ENCRYPTION_KEY=<your-64-char-hex-key>
+```
+
+This keeps the key out of the per-server config file while still making it available to the server process.
+
+### 3. Encrypt a credential value
 
 ```bash
 npm run build
 FTP_ENCRYPTION_KEY=<your-64-char-hex-key> npm run encrypt-env -- <plaintext-value>
 ```
 
+If you already stored the key in the keychain or your shell profile, the variable is picked up automatically:
+
+```bash
+npm run encrypt-env -- <plaintext-value>
+```
+
 The output is a self-contained encrypted string in the format `enc:<iv_hex>:<tag_hex>:<ciphertext_hex>`.
 
-### 3. Use the encrypted values in your config
+### 4. Use the encrypted values in your config
 
-Set `FTP_ENCRYPTION_KEY` alongside the encrypted credentials. Values that do not start with `enc:` are treated as plaintext, so you can encrypt selectively.
+Place only the encrypted credentials in the config. **Do not add `FTP_ENCRYPTION_KEY` here** — the server retrieves it from the keychain or your shell environment.
 
 ```json
 {
@@ -209,13 +238,14 @@ Set `FTP_ENCRYPTION_KEY` alongside the encrypted credentials. Values that do not
         "FTP_PORT": "21",
         "FTP_USER": "enc:aabbcc...:ddeeff...:112233...",
         "FTP_PASSWORD": "enc:aabbcc...:ddeeff...:112233...",
-        "FTP_SECURE": "false",
-        "FTP_ENCRYPTION_KEY": "<your-64-char-hex-key>"
+        "FTP_SECURE": "false"
       }
     }
   }
 }
 ```
+
+Values that do not start with `enc:` are treated as plaintext, so you can encrypt selectively.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node build/index.js",
     "dev": "npm run build && npm start",
     "prepublishOnly": "npm run build",
-    "encrypt-env": "node --input-type=module -e \"const {loadEncryptionKey}=await import('./build/keychain.js');await loadEncryptionKey();const {encrypt}=await import('./build/crypto.js');const plaintext=process.argv[2];if(!plaintext){console.error('Usage: npm run encrypt-env -- <plaintext>');process.exit(1);}console.log(encrypt(plaintext));\"",
+    "encrypt-env": "node scripts/encrypt-env.js",
     "store-key": "node scripts/store-key.js"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "node build/index.js",
     "dev": "npm run build && npm start",
     "prepublishOnly": "npm run build",
-    "encrypt-env": "node -e \"const {encrypt}=await import('./build/crypto.js');const plaintext=process.argv[2];if(!plaintext){console.error('Usage: npm run encrypt-env -- <plaintext>');process.exit(1);}console.log(encrypt(plaintext))\" --input-type=module"
+    "encrypt-env": "node --input-type=module -e \"const {loadEncryptionKey}=await import('./build/keychain.js');await loadEncryptionKey();const {encrypt}=await import('./build/crypto.js');const plaintext=process.argv[2];if(!plaintext){console.error('Usage: npm run encrypt-env -- <plaintext>');process.exit(1);}console.log(encrypt(plaintext));\"",
+    "store-key": "node scripts/store-key.js"
   },
   "keywords": [
     "mcp",
@@ -41,5 +42,8 @@
   ],
   "engines": {
     "node": ">=16.0.0"
+  },
+  "optionalDependencies": {
+    "keytar": "^7.9.0"
   }
 }

--- a/scripts/encrypt-env.js
+++ b/scripts/encrypt-env.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Encrypts a plaintext credential value using the AES-256-GCM key stored in
+ * the OS keychain (or FTP_ENCRYPTION_KEY env var as fallback).
+ *
+ * Build first:
+ *   npm run build
+ *
+ * Usage:
+ *   node scripts/encrypt-env.js <plaintext-value>
+ *   npm run encrypt-env -- <plaintext-value>
+ *
+ * Output is an `enc:<iv>:<tag>:<ciphertext>` string ready to paste into your
+ * MCP config as FTP_USER, FTP_PASSWORD, or FTP_PASSPHRASE.
+ */
+import { loadEncryptionKey } from "../build/keychain.js";
+import { encrypt } from "../build/crypto.js";
+
+const USAGE =
+  "Usage: run `npm run build` first, then: node scripts/encrypt-env.js <plaintext-value>";
+
+const plaintext = process.argv[2];
+if (!plaintext) {
+  console.error(USAGE);
+  process.exit(1);
+}
+
+try {
+  await loadEncryptionKey();
+  console.log(encrypt(plaintext));
+} catch (err) {
+  console.error(
+    "Failed to encrypt value. Ensure FTP_ENCRYPTION_KEY is stored in the OS keychain or set as an environment variable.",
+    err instanceof Error ? err.message : err
+  );
+  process.exit(1);
+}

--- a/scripts/store-key.js
+++ b/scripts/store-key.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Stores the FTP encryption key in the OS keychain so it does not need to be
+ * embedded in the Claude Desktop config file.
+ *
+ * Build first:
+ *   npm run build
+ *
+ * Usage:
+ *   node scripts/store-key.js <64-char-hex-key>
+ *
+ * The key is then retrieved automatically at server start-up via the OS
+ * keychain (macOS Keychain, Windows Credential Manager, or Linux Secret
+ * Service) without needing FTP_ENCRYPTION_KEY in the MCP config env block.
+ */
+import { storeEncryptionKey } from "../build/keychain.js";
+
+const USAGE =
+  "Usage: run `npm run build` first, then: node scripts/store-key.js <64-char-hex-key>";
+
+const key = process.argv[2];
+if (!key) {
+  console.error(USAGE);
+  process.exit(1);
+}
+
+if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+  console.error("Invalid key: expected a 64-character hexadecimal string.");
+  console.error(USAGE);
+  process.exit(1);
+}
+
+try {
+  await storeEncryptionKey(key);
+  console.log("Encryption key stored in OS keychain.");
+} catch (err) {
+  console.error(
+    "Failed to store encryption key. Ensure optional dependency keytar is installed and your OS keychain is available.",
+    err instanceof Error ? err.message : err
+  );
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { FtpClient, FtpConfig } from "./ftp-client.js";
 import { SftpClient, SftpConfig } from "./sftp-client.js";
 import { decrypt } from "./crypto.js";
 import { ConnectionType } from "./connection-type.js";
+import { loadEncryptionKey } from "./keychain.js";
 
 function resolveSecure(raw: string | undefined): boolean {
   const v = raw?.trim().toLowerCase();
@@ -250,6 +251,8 @@ function formatSize(bytes: number): string {
 
 // Initialize and run the server
 async function main() {
+  // Load encryption key from OS keychain before decrypting any credentials
+  await loadEncryptionKey();
   try {
     const protocol = resolveProtocol(process.env.FTP_PROTOCOL);
     const host = process.env.FTP_HOST || "localhost";

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,0 +1,49 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const KEYCHAIN_SERVICE = "mcp-server-ftp";
+const KEYCHAIN_ACCOUNT = "FTP_ENCRYPTION_KEY";
+
+// keytar is a CJS module; ESM named-export interop is incomplete (e.g.
+// setPassword only appears on the default export). Always use .default.
+async function importKeytar() {
+  // Load via createRequire so TypeScript does not need to resolve the
+  // optional dependency at compile time.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require("keytar");
+  return mod.default ?? mod;
+}
+
+/**
+ * Attempts to load FTP_ENCRYPTION_KEY from the OS keychain (macOS Keychain,
+ * Windows Credential Manager, or Linux Secret Service via keytar).
+ *
+ * If the key is already present in process.env.FTP_ENCRYPTION_KEY it is left
+ * untouched. If keytar is not installed, or the key has not been stored yet,
+ * the function returns silently — the caller can still supply the key through
+ * the real process environment (e.g. shell profile).
+ */
+export async function loadEncryptionKey(): Promise<void> {
+  if (process.env.FTP_ENCRYPTION_KEY) return;
+
+  try {
+    // keytar is an optional dependency — import dynamically so the server
+    // starts normally when it is not installed.
+    const keytar = await importKeytar();
+    const key = await keytar.getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    if (key) {
+      process.env.FTP_ENCRYPTION_KEY = key;
+    }
+  } catch {
+    // keytar unavailable or keychain lookup failed — fall back to env var only
+  }
+}
+
+/**
+ * Stores the given key in the OS keychain so it can be retrieved later by
+ * {@link loadEncryptionKey} without being embedded in a config file.
+ */
+export async function storeEncryptionKey(key: string): Promise<void> {
+  const keytar = await importKeytar();
+  await keytar.setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, key);
+}

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -5,20 +5,42 @@ const require = createRequire(import.meta.url);
 const KEYCHAIN_SERVICE = "mcp-server-ftp";
 const KEYCHAIN_ACCOUNT = "FTP_ENCRYPTION_KEY";
 
+// Shared type for errors thrown by execFileSync.
+type ExecError = Error & { status?: number | null; stderr?: Buffer | string | null };
+
+/** Extracts a human-readable string from an execFileSync stderr field. */
+function extractStderr(err: ExecError): string {
+  const raw = err.stderr;
+  if (Buffer.isBuffer(raw)) return raw.toString("utf8").trim();
+  if (typeof raw === "string") return raw.trim();
+  return "";
+}
+
 // ---------------------------------------------------------------------------
 // macOS `security` CLI — no native binary, works on any Node architecture
 // ---------------------------------------------------------------------------
 
+/**
+ * Returns the stored key, or null when the item does not exist yet (exit 44).
+ * Throws on real failures (keychain locked, ACL denied, `security` unavailable)
+ * so the caller can distinguish "not set up yet" from "something is wrong".
+ */
 function macosGet(): string | null {
   try {
     const out = execFileSync(
       "security",
       ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w"],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
     );
     return out.trim() || null;
-  } catch {
-    return null;
+  } catch (err: unknown) {
+    const execErr = err as ExecError;
+    // Exit code 44 = errSecItemNotFound — key simply hasn't been stored yet.
+    if (execErr.status === 44) return null;
+    // Any other failure is a real error (keychain locked, ACL denied, etc.)
+    const stderr = extractStderr(execErr);
+    const detail = stderr || execErr.message || `exit code ${execErr.status ?? "unknown"}`;
+    throw new Error(`Failed to read from macOS Keychain via \`security\` CLI: ${detail}`);
   }
 }
 
@@ -39,18 +61,12 @@ function macosSet(key: string): void {
       { stdio: ["ignore", "ignore", "pipe"] }
     );
   } catch (err: unknown) {
-    const raw =
-      err instanceof Error && "stderr" in err
-        ? (err as NodeJS.ErrnoException & { stderr?: Buffer | string | null }).stderr
-        : undefined;
-    const stderr = Buffer.isBuffer(raw)
-      ? raw.toString("utf8").trim()
-      : typeof raw === "string"
-        ? raw.trim()
-        : "";
-    throw new Error(
-      `Failed to write to macOS Keychain via \`security\` CLI${stderr ? `: ${stderr}` : "."}`
-    );
+    const execErr = err as ExecError;
+    const stderr = extractStderr(execErr);
+    // Prefer stderr from the CLI; fall back to the error's own message so
+    // there is always something actionable in the thrown error.
+    const detail = stderr || execErr.message || `exit code ${execErr.status ?? "unknown"}`;
+    throw new Error(`Failed to write to macOS Keychain via \`security\` CLI: ${detail}`);
   }
 }
 
@@ -82,6 +98,10 @@ async function keytarSet(key: string): Promise<void> {
  *  2. keytar — Windows Credential Manager / Linux Secret Service
  *  3. Silent fall-through — caller can still supply via process environment
  *
+ * Real keychain errors (e.g. locked keychain) are logged to stderr but do
+ * not throw — the server can still start if the key is supplied via the
+ * process environment.
+ *
  * If the key is already present in process.env.FTP_ENCRYPTION_KEY it is left
  * untouched.
  */
@@ -91,9 +111,19 @@ export async function loadEncryptionKey(): Promise<void> {
   if (process.platform === "darwin") {
     // Use security CLI exclusively on macOS — keytar is not attempted here to
     // avoid native-addon architecture conflicts on Apple Silicon / Rosetta.
-    const key = macosGet();
-    if (key) {
-      process.env.FTP_ENCRYPTION_KEY = key;
+    try {
+      const key = macosGet();
+      if (key) {
+        process.env.FTP_ENCRYPTION_KEY = key;
+      }
+    } catch (err) {
+      // macosGet() only throws on real errors (not "item not found").
+      // Log a warning but do not crash — the caller can still supply the key
+      // via the process environment.
+      console.error(
+        "Warning: macOS Keychain lookup failed:",
+        err instanceof Error ? err.message : String(err)
+      );
     }
     return;
   }

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -98,9 +98,10 @@ async function keytarSet(key: string): Promise<void> {
  *  2. keytar — Windows Credential Manager / Linux Secret Service
  *  3. Silent fall-through — caller can still supply via process environment
  *
- * Real keychain errors (e.g. locked keychain) are logged to stderr but do
- * not throw — the server can still start if the key is supplied via the
- * process environment.
+ * Real keychain errors (e.g. locked keychain) are logged to stderr as a
+ * warning but do not throw — the server can still start if the key is
+ * supplied via the process environment. This applies to both the macOS
+ * security CLI path and the keytar path (Windows / Linux).
  *
  * If the key is already present in process.env.FTP_ENCRYPTION_KEY it is left
  * untouched.
@@ -133,8 +134,13 @@ export async function loadEncryptionKey(): Promise<void> {
     if (key) {
       process.env.FTP_ENCRYPTION_KEY = key;
     }
-  } catch {
-    // keytar unavailable or keychain lookup failed — fall back to env var only
+  } catch (err) {
+    // keytar unavailable or keychain lookup failed — log a warning and fall
+    // back to env var so the server can still start.
+    console.error(
+      "Warning: keychain lookup via keytar failed:",
+      err instanceof Error ? err.message : String(err)
+    );
   }
 }
 

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
@@ -23,12 +23,30 @@ function macosGet(): string | null {
 }
 
 function macosSet(key: string): void {
-  // -U updates an existing entry; creates one if absent
-  execFileSync(
-    "security",
-    ["add-generic-password", "-U", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w", key],
-    { stdio: "ignore" }
-  );
+  // -U updates an existing entry; creates one if absent.
+  //
+  // Security note: the key is passed as a command-line argument, which means
+  // it is briefly visible in process listings (e.g. `ps aux`) during the
+  // fraction of a second this command runs. The `security` CLI provides no
+  // stdin interface for `add-generic-password`, so there is no argv-free
+  // alternative without shelling out to Swift/AppleScript. This exposure is
+  // limited to the one-time `npm run store-key` setup step and does not
+  // affect the server's read path (`find-generic-password` outputs to stdout).
+  try {
+    execFileSync(
+      "security",
+      ["add-generic-password", "-U", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w", key],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+  } catch (err: unknown) {
+    const stderr =
+      err instanceof Error && "stderr" in err
+        ? String((err as NodeJS.ErrnoException & { stderr?: Buffer }).stderr).trim()
+        : "";
+    throw new Error(
+      `Failed to write to macOS Keychain via \`security\` CLI${stderr ? `: ${stderr}` : "."}`
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -39,9 +39,14 @@ function macosSet(key: string): void {
       { stdio: ["ignore", "ignore", "pipe"] }
     );
   } catch (err: unknown) {
-    const stderr =
+    const raw =
       err instanceof Error && "stderr" in err
-        ? String((err as NodeJS.ErrnoException & { stderr?: Buffer }).stderr).trim()
+        ? (err as NodeJS.ErrnoException & { stderr?: Buffer | string | null }).stderr
+        : undefined;
+    const stderr = Buffer.isBuffer(raw)
+      ? raw.toString("utf8").trim()
+      : typeof raw === "string"
+        ? raw.trim()
         : "";
     throw new Error(
       `Failed to write to macOS Keychain via \`security\` CLI${stderr ? `: ${stderr}` : "."}`

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -1,36 +1,80 @@
+import { execSync, execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 const KEYCHAIN_SERVICE = "mcp-server-ftp";
 const KEYCHAIN_ACCOUNT = "FTP_ENCRYPTION_KEY";
 
-// keytar is a CJS module; ESM named-export interop is incomplete (e.g.
-// setPassword only appears on the default export). Always use .default.
-async function importKeytar() {
-  // Load via createRequire so TypeScript does not need to resolve the
-  // optional dependency at compile time.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const mod = require("keytar");
-  return mod.default ?? mod;
+// ---------------------------------------------------------------------------
+// macOS `security` CLI — no native binary, works on any Node architecture
+// ---------------------------------------------------------------------------
+
+function macosGet(): string | null {
+  try {
+    const out = execFileSync(
+      "security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    );
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
+function macosSet(key: string): void {
+  // -U updates an existing entry; creates one if absent
+  execFileSync(
+    "security",
+    ["add-generic-password", "-U", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w", key],
+    { stdio: "ignore" }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// keytar fallback — Windows Credential Manager / Linux Secret Service
+// ---------------------------------------------------------------------------
+
+async function keytarGet(): Promise<string | null> {
+  const mod = require("keytar");
+  const keytar = mod.default ?? mod;
+  return keytar.getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+}
+
+async function keytarSet(key: string): Promise<void> {
+  const mod = require("keytar");
+  const keytar = mod.default ?? mod;
+  await keytar.setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, key);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
- * Attempts to load FTP_ENCRYPTION_KEY from the OS keychain (macOS Keychain,
- * Windows Credential Manager, or Linux Secret Service via keytar).
+ * Attempts to load FTP_ENCRYPTION_KEY from the OS keychain.
+ *
+ * Strategy (in order):
+ *  1. macOS `security` CLI — arch-independent, no native module required
+ *  2. keytar — Windows Credential Manager / Linux Secret Service
+ *  3. Silent fall-through — caller can still supply via process environment
  *
  * If the key is already present in process.env.FTP_ENCRYPTION_KEY it is left
- * untouched. If keytar is not installed, or the key has not been stored yet,
- * the function returns silently — the caller can still supply the key through
- * the real process environment (e.g. shell profile).
+ * untouched.
  */
 export async function loadEncryptionKey(): Promise<void> {
   if (process.env.FTP_ENCRYPTION_KEY) return;
 
+  if (process.platform === "darwin") {
+    const key = macosGet();
+    if (key) {
+      process.env.FTP_ENCRYPTION_KEY = key;
+      return;
+    }
+  }
+
   try {
-    // keytar is an optional dependency — import dynamically so the server
-    // starts normally when it is not installed.
-    const keytar = await importKeytar();
-    const key = await keytar.getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    const key = await keytarGet();
     if (key) {
       process.env.FTP_ENCRYPTION_KEY = key;
     }
@@ -40,10 +84,16 @@ export async function loadEncryptionKey(): Promise<void> {
 }
 
 /**
- * Stores the given key in the OS keychain so it can be retrieved later by
- * {@link loadEncryptionKey} without being embedded in a config file.
+ * Stores the given key in the OS keychain.
+ *
+ * Strategy (in order):
+ *  1. macOS `security` CLI
+ *  2. keytar (Windows / Linux)
  */
 export async function storeEncryptionKey(key: string): Promise<void> {
-  const keytar = await importKeytar();
-  await keytar.setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, key);
+  if (process.platform === "darwin") {
+    macosSet(key);
+    return;
+  }
+  await keytarSet(key);
 }

--- a/src/keychain.ts
+++ b/src/keychain.ts
@@ -66,11 +66,13 @@ export async function loadEncryptionKey(): Promise<void> {
   if (process.env.FTP_ENCRYPTION_KEY) return;
 
   if (process.platform === "darwin") {
+    // Use security CLI exclusively on macOS — keytar is not attempted here to
+    // avoid native-addon architecture conflicts on Apple Silicon / Rosetta.
     const key = macosGet();
     if (key) {
       process.env.FTP_ENCRYPTION_KEY = key;
-      return;
     }
+    return;
   }
 
   try {


### PR DESCRIPTION
## Summary

Storing `FTP_ENCRYPTION_KEY` alongside encrypted credentials in the Claude Desktop config file negates most of the security benefit — if the file is leaked, both the key and the ciphertext are exposed together. This PR moves the encryption key out of the config file and into the OS keychain.

**What changes:**

- `src/keychain.ts` — new module with two helpers: `loadEncryptionKey()` (reads from OS keychain at startup, silently falls back to env var if keytar is unavailable or key not stored) and `storeEncryptionKey()` (one-time write to keychain)
- `src/index.ts` — calls `await loadEncryptionKey()` at the top of `main()` before any credential decryption
- `package.json` — adds `store-key` npm script, updates `encrypt-env` to load from keychain first, declares `keytar` as an optional dependency (install never fails without native build tools)
- `scripts/store-key.ts` — standalone CLI helper backing the `npm run store-key` command
- `README.md` — rewrites the Credential Encryption section to lead with keychain storage, documents Option B (global shell env var), and shows a config example with no `FTP_ENCRYPTION_KEY` in the `env` block

## Setup (one-time)

```bash
npm run build
npm run store-key -- <your-64-char-hex-key>
```

Then remove `FTP_ENCRYPTION_KEY` from your MCP config `env` block. The server loads it automatically from the OS keychain on each start.

## Security model

- macOS: stored in Keychain Access, protected by login session
- Windows: Windows Credential Manager
- Linux: Secret Service (e.g. GNOME Keyring)
- If `keytar` is not installed or the keychain lookup fails, the server falls back to `FTP_ENCRYPTION_KEY` in the process environment — behaviour is identical to before this PR

## Test plan

- [x] `npm run store-key -- <key>` stores key without error
- [x] MCP server connects and decrypts credentials with no `FTP_ENCRYPTION_KEY` in config
- [x] Server still works when `FTP_ENCRYPTION_KEY` is supplied via env var (fallback path)
- [x] Server still starts when `keytar` is not installed (optional dep, catch block)
- [x] `npm run encrypt-env -- <value>` picks up key from keychain without requiring `FTP_ENCRYPTION_KEY` in shell