### PR TITLE
feat: read SFTP private key from 1Password CLI via op:// secret references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `FTP_PRIVATE_KEY_PATH` now accepts a 1Password secret reference (`op://vault/item/field`), resolved via the 1Password CLI (`op read`) so the SFTP private key never has to live in a file on disk. The key is cached in memory for the process lifetime; plain file paths and `~/.ssh` auto-detection are unchanged.
+
 ## 1.2.0 — 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you encounter build issues on Windows:
 | `FTP_PASSWORD` | FTP password (supports encryption) | (empty string) |
 | `FTP_SECURE` | Use secure FTP (FTPS), ignored when `FTP_PROTOCOL=sftp` | false |
 | `FTP_PROTOCOL` | Protocol to use: `ftp` or `sftp` | ftp |
-| `FTP_PRIVATE_KEY_PATH` | Path to SSH private key for SFTP (e.g. `~/.ssh/id_ed25519`) | (auto-detect) |
+| `FTP_PRIVATE_KEY_PATH` | Path to SSH private key for SFTP (e.g. `~/.ssh/id_ed25519`), or a 1Password secret reference (e.g. `op://Private/my-server/private key`) | (auto-detect) |
 | `FTP_PASSPHRASE` | Passphrase for the SSH private key (supports encryption) | (empty string) |
 | `FTP_ENCRYPTION_KEY` | 64-character hex AES-256 key for decrypting credentials — store in OS keychain, not here | (disabled) |
 
@@ -161,10 +161,31 @@ SFTP supports two authentication methods, chosen automatically:
 
 The server looks for a private key in this order:
 
-1. The path in `FTP_PRIVATE_KEY_PATH` (if set)
+1. The path or 1Password reference in `FTP_PRIVATE_KEY_PATH` (if set)
 2. `~/.ssh/id_ed25519`
 3. `~/.ssh/id_rsa`
 4. `~/.ssh/id_ecdsa`
+
+#### Reading the key from 1Password
+
+Instead of keeping the private key in a file on disk, you can store it as an SSH Key item in 1Password and point `FTP_PRIVATE_KEY_PATH` at a [secret reference](https://developer.1password.com/docs/cli/secret-references/):
+
+```json
+"FTP_PRIVATE_KEY_PATH": "op://Private/my-server/private key"
+```
+
+Requirements:
+
+- The [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) must be installed and on `PATH`.
+- The CLI must be able to authenticate — either through the 1Password desktop app integration (the first read may trigger a biometric/authorization prompt) or a service account token in `OP_SERVICE_ACCOUNT_TOKEN`.
+
+The key is fetched once per server process and cached in memory, so you are not prompted on every SFTP operation. It is never written to disk.
+
+If your server rejects the key format, append `?ssh-format=openssh` to the reference to force OpenSSH private key format:
+
+```json
+"FTP_PRIVATE_KEY_PATH": "op://Private/my-server/private key?ssh-format=openssh"
+```
 
 ### Configuration example
 

--- a/src/onepassword.ts
+++ b/src/onepassword.ts
@@ -1,0 +1,54 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// Generous ceiling for the desktop-app authorization prompt; without it an
+// unanswered prompt would hang the MCP tool call indefinitely.
+const OP_READ_TIMEOUT_MS = 120_000;
+
+/**
+ * Returns true when the value is a 1Password secret reference
+ * (e.g. "op://Private/ssh key/private key").
+ */
+export function isOnePasswordRef(value: string): boolean {
+  return value.startsWith("op://");
+}
+
+/**
+ * Resolves a 1Password secret reference via the 1Password CLI (`op read`).
+ *
+ * Requires the `op` CLI to be installed and authenticated — either through
+ * the 1Password desktop app integration (may trigger a biometric prompt) or
+ * a service account token in OP_SERVICE_ACCOUNT_TOKEN.
+ */
+export async function readOnePasswordSecret(ref: string): Promise<string> {
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync("op", ["read", "--no-newline", ref], {
+      timeout: OP_READ_TIMEOUT_MS,
+    }));
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string; killed?: boolean };
+    if (err.code === "ENOENT") {
+      throw new Error(
+        `Cannot resolve "${ref}": the 1Password CLI (op) is not installed or not on PATH. ` +
+          `Install it from https://developer.1password.com/docs/cli/ or use a file path instead.`
+      );
+    }
+    if (err.killed) {
+      throw new Error(
+        `Timed out reading "${ref}" from 1Password after ${OP_READ_TIMEOUT_MS / 1000}s — ` +
+          `the authorization prompt may not have been answered.`
+      );
+    }
+    const detail = err.stderr?.trim() || err.message;
+    throw new Error(`Failed to read "${ref}" from 1Password CLI: ${detail}`);
+  }
+  if (!stdout.trim()) {
+    throw new Error(
+      `1Password returned no data for "${ref}". Check that the reference points to a non-empty field.`
+    );
+  }
+  return stdout;
+}

--- a/src/sftp-client.ts
+++ b/src/sftp-client.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 import { isUtf8 } from "buffer";
 import { randomUUID } from "crypto";
 import type { FileEncoding } from "./ftp-client.js";
+import { isOnePasswordRef, readOnePasswordSecret } from "./onepassword.js";
 
 export interface SftpConfig {
   host: string;
@@ -12,7 +13,7 @@ export interface SftpConfig {
   user: string;
   password: string;
   passphrase: string;     // decrypted passphrase for SSH private key; ignored when no key is found
-  privateKeyPath: string; // path to SSH private key
+  privateKeyPath: string; // path to SSH private key, or a 1Password reference (op://vault/item/field)
 }
 
 function resolvePrivateKey(keyPath: string): Buffer | undefined {
@@ -37,6 +38,7 @@ type FileEntry = { name: string; type: string; size: number; modifiedDate: strin
 export class SftpClient {
   private config: SftpConfig;
   private tempDir: string;
+  private privateKeyPromise: Promise<Buffer | undefined> | undefined;
 
   constructor(config: SftpConfig) {
     this.config = config;
@@ -44,15 +46,31 @@ export class SftpClient {
     if (!fs.existsSync(this.tempDir)) fs.mkdirSync(this.tempDir, { recursive: true });
   }
 
-  private buildClientOptions() {
-    // Resolve key from explicit path first, then fall back to ~/.ssh defaults
+  // Resolve key from explicit path or 1Password reference first, then fall
+  // back to ~/.ssh defaults. The in-flight promise is memoized so concurrent
+  // first-time connections share one resolution — 1Password is consulted at
+  // most once per process (each read may trigger an authorization prompt).
+  // Failures are not cached, so a transient error stays retryable.
+  private resolvePrivateKeyMaterial(): Promise<Buffer | undefined> {
+    this.privateKeyPromise ??= this.loadPrivateKey().catch((error) => {
+      this.privateKeyPromise = undefined;
+      throw error;
+    });
+    return this.privateKeyPromise;
+  }
+
+  private async loadPrivateKey(): Promise<Buffer | undefined> {
     let privateKey: Buffer | undefined;
     if (this.config.privateKeyPath) {
-      privateKey = resolvePrivateKey(this.config.privateKeyPath);
-      if (!privateKey) {
-        throw new Error(
-          `FTP_PRIVATE_KEY_PATH is set to "${this.config.privateKeyPath}" but no key could be read from that path.`
-        );
+      if (isOnePasswordRef(this.config.privateKeyPath)) {
+        privateKey = Buffer.from(await readOnePasswordSecret(this.config.privateKeyPath));
+      } else {
+        privateKey = resolvePrivateKey(this.config.privateKeyPath);
+        if (!privateKey) {
+          throw new Error(
+            `FTP_PRIVATE_KEY_PATH is set to "${this.config.privateKeyPath}" but no key could be read from that path.`
+          );
+        }
       }
     } else {
       for (const p of DEFAULT_KEY_PATHS) {
@@ -60,6 +78,12 @@ export class SftpClient {
         if (privateKey) break;
       }
     }
+
+    return privateKey;
+  }
+
+  private async buildClientOptions() {
+    const privateKey = await this.resolvePrivateKeyMaterial();
 
     const clientOptions: Record<string, unknown> = {
       host: this.config.host,
@@ -80,7 +104,7 @@ export class SftpClient {
   async listDirectory(remotePath: string): Promise<FileEntry[]> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       const list = await client.list(remotePath);
       return list.map((item) => ({
         name: item.name,
@@ -97,7 +121,7 @@ export class SftpClient {
     const client = new Ssh2SftpClient();
     const tempFilePath = path.join(this.tempDir, `download-${randomUUID()}-${path.basename(remotePath)}`);
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.fastGet(remotePath, tempFilePath);
       // Read as raw bytes; only decode as utf8 when the content actually is valid utf8,
       // otherwise fall back to base64 so binary files survive the round trip
@@ -117,7 +141,7 @@ export class SftpClient {
     const tempFilePath = path.join(this.tempDir, `upload-${randomUUID()}-${path.basename(remotePath)}`);
     try {
       fs.writeFileSync(tempFilePath, Buffer.from(content, encoding));
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.fastPut(tempFilePath, remotePath);
       return true;
     } finally {
@@ -129,7 +153,7 @@ export class SftpClient {
   async createDirectory(remotePath: string): Promise<boolean> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.mkdir(remotePath, true);
       return true;
     } finally {
@@ -140,7 +164,7 @@ export class SftpClient {
   async deleteFile(remotePath: string): Promise<boolean> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.delete(remotePath);
       return true;
     } finally {
@@ -151,7 +175,7 @@ export class SftpClient {
   async deleteDirectory(remotePath: string): Promise<boolean> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.rmdir(remotePath, true);
       return true;
     } finally {
@@ -162,7 +186,7 @@ export class SftpClient {
   async appendFile(remotePath: string, content: string, encoding: FileEncoding = "utf8"): Promise<boolean> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.append(Buffer.from(content, encoding), remotePath);
       return true;
     } finally {
@@ -173,7 +197,7 @@ export class SftpClient {
   async rename(fromPath: string, toPath: string): Promise<boolean> {
     const client = new Ssh2SftpClient();
     try {
-      await client.connect(this.buildClientOptions());
+      await client.connect(await this.buildClientOptions());
       await client.rename(fromPath, toPath);
       return true;
     } finally {


### PR DESCRIPTION
## Summary

Adds the ability to keep the SFTP private key in 1Password instead of a file on disk. When `FTP_PRIVATE_KEY_PATH` starts with `op://` it is treated as a [1Password secret reference](https://developer.1password.com/docs/cli/secret-references/) and resolved through the 1Password CLI (`op read`):

```json
"FTP_PRIVATE_KEY_PATH": "op://Private/my-server/private key"
```

Plain file paths and the `~/.ssh` auto-detection are unchanged, and the auto-detect fallback never contacts 1Password — resolution only happens for an explicit `op://` value. Users without the `op` CLI are unaffected.

## Implementation

- **New `src/onepassword.ts`** (54 lines) — detects `op://` references and resolves them with `execFile("op", ["read", "--no-newline", ref])`: argument-vector exec with no shell, so no injection risk. Runs under a 120s timeout so an unanswered 1Password desktop authorization prompt fails with a clear error instead of hanging the MCP tool call. Targeted errors for each failure mode: CLI not installed (with install link), timeout, empty field, and anything else (surfacing `op`'s own stderr, e.g. "not signed in").
- **`src/sftp-client.ts`** — key resolution moves into an async `resolvePrivateKeyMaterial()` that handles both sources. The in-flight promise is memoized so concurrent first-time connections share a single `op read` — at most one authorization prompt per process; rejections clear the memo so transient failures stay retryable. Key material lives in memory only and is never written to disk or logged.
- **`README.md` / `CHANGELOG.md`** — documents the reference syntax, auth requirements (desktop-app integration or `OP_SERVICE_ACCOUNT_TOKEN` for headless use), and the `?ssh-format=openssh` query parameter for servers that reject 1Password's default (PKCS#8) key export; adds an Unreleased changelog entry.

## Motivation

The server already goes out of its way to keep secrets out of config files (AES-encrypted credentials, OS-keychain encryption key). The SSH private key was the remaining secret that had to exist as a plaintext file on disk; this closes that gap for 1Password users.

## Testing

Verified against a clean build (`tsc`, SDK ^1.12.0) of this branch, using a stub `op` binary where CLI behavior is involved:

- [x] `op://` values are detected as references; plain paths are not
- [x] File-path resolution unchanged: key material + passphrase passed through to ssh2 options
- [x] Missing `op` CLI produces the install-hint error instead of a raw ENOENT
- [x] Secret resolution returns `op read` stdout verbatim (`--no-newline`)
- [x] Empty/whitespace `op read` output is rejected with a clear error instead of reaching ssh2 as a zero-length key
- [x] Concurrent first-time resolutions share one in-flight promise; failures are not cached (retry re-attempts)
- [x] Existing `SftpClient` methods (`appendFile`, `rename`, `downloadFile`, …) intact
- [x] Server startup with an `op://` key configured does not invoke the CLI — resolution is lazy until the first connection, so no surprise authorization prompt at boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)