### PR TITLE
Document release workflow and update Smithery links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing
+
+Use pull requests for code changes. Keep releases separate from development work so npm and Smithery only get code that is already on `main`.
+
+## Before opening a pull request
+
+Create a branch from `main`, make the change, then run:
+
+```bash
+npm install
+npm run build
+```
+
+If the change affects user-facing behavior, update `README.md` and `CHANGELOG.md` in the same pull request.
+
+Do not commit passwords, API keys, npm tokens, Smithery tokens, private keys, or generated credential files.
+
+## Version updates
+
+For a release, update the version in both:
+
+- `package.json`
+- `manifest.json`
+
+Keep the two versions identical.
+
+Build the project before publishing:
+
+```bash
+npm install
+npm run build
+```
+
+## Publish to npm
+
+The package name is `mcp-server-ftp`.
+
+You need publish access to the package on npm. Once the release changes are merged to `main`:
+
+```bash
+npm login
+npm publish
+```
+
+Check the published version:
+
+```bash
+npm view mcp-server-ftp version
+```
+
+Do not publish from an unmerged feature branch unless the release is intentionally a prerelease.
+
+## Publish to Smithery
+
+The Smithery server is owned by the team account:
+
+```text
+alxspikers-team/mcp-server-ftp
+```
+
+You need access to that Smithery team before publishing.
+
+Smithery uses an `.mcpb` bundle. This repository's `manifest.json` includes `tools[].inputSchema`, which Smithery expects but Anthropic's MCPB validator rejects. Package the bundle as a normal ZIP instead of using `mcpb pack`.
+
+Start from a clean checkout of the merged release on `main`:
+
+```bash
+npm install
+npm run build
+```
+
+Create a temporary staging directory and copy these files into it:
+
+```text
+build/
+package.json
+manifest.json
+LICENSE
+README.md
+```
+
+Inside the staging directory, install production dependencies only:
+
+```bash
+npm install --omit=dev --ignore-scripts
+```
+
+Create the bundle from inside that staging directory:
+
+```bash
+zip -r bundle.mcpb .
+```
+
+Publish it to the team listing:
+
+```bash
+smithery mcp publish bundle.mcpb -n alxspikers-team/mcp-server-ftp
+```
+
+After publishing, open the Smithery listing and confirm the new version is shown.
+
+## Release checklist
+
+Before calling a release finished, check that:
+
+- the release commit is on `main`
+- `package.json` and `manifest.json` have the same version
+- `npm run build` passes
+- npm shows the new package version
+- Smithery shows the new server version
+
+GitHub access alone does not grant npm or Smithery publishing access. Each registry has its own maintainer permissions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,13 @@ Do not commit passwords, API keys, npm tokens, Smithery tokens, private keys, or
 
 ## Version updates
 
-For a release, update the version in both:
+For a release, update the version in all three places:
 
 - `package.json`
 - `manifest.json`
+- the `version` passed to `McpServer` in `src/index.ts`
 
-Keep the two versions identical.
+Keep all three versions identical. The value in `src/index.ts` is reported by the server during MCP initialization, so leaving it unchanged would make the running server report an older version than npm and Smithery.
 
 Build the project before publishing:
 
@@ -104,7 +105,7 @@ After publishing, open the Smithery listing and confirm the new version is shown
 Before calling a release finished, check that:
 
 - the release commit is on `main`
-- `package.json` and `manifest.json` have the same version
+- `package.json`, `manifest.json`, and `src/index.ts` have the same version
 - `npm run build` passes
 - npm shows the new package version
 - Smithery shows the new server version

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ After configuring and restarting Claude for Desktop, you can use natural languag
 | `upload-file` | Upload a file to the FTP server (pass `encoding: "base64"` for binary content) |
 | `create-directory` | Create a new directory on the FTP server |
 | `delete-file` | Delete a file from the FTP server |
-| `delete-directory` | Delete a directory on the FTP server |
+| `delete-directory` | Delete a directory from the FTP server |
 | `rename-file` | Rename or move a file or directory on the FTP server |
 | `edit-file` | Replace an exact string in a text file without re-uploading the whole file content |
 | `append-file` | Append content to a file (creates it if missing) |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # MCP Server for FTP Access
 
-[![smithery badge](https://smithery.ai/badge/@alxspiker/mcp-server-ftp)](https://smithery.ai/server/@alxspiker/mcp-server-ftp)
+[![smithery badge](https://smithery.ai/badge/alxspikers-team/mcp-server-ftp)](https://smithery.ai/servers/alxspikers-team/mcp-server-ftp)
 
 This Model Context Protocol (MCP) server provides tools for interacting with FTP servers. It allows Claude.app to list directories, download and upload files, create directories, and delete files/directories on FTP servers.
 
@@ -18,10 +18,10 @@ This Model Context Protocol (MCP) server provides tools for interacting with FTP
 
 ### Installing via Smithery
 
-To install mcp-server-ftp for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@alxspiker/mcp-server-ftp):
+To install mcp-server-ftp for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/alxspikers-team/mcp-server-ftp):
 
 ```bash
-npx -y @smithery/cli install @alxspiker/mcp-server-ftp --client claude
+npx -y @smithery/cli install alxspikers-team/mcp-server-ftp --client claude
 ```
 
 ### Prerequisites
@@ -304,7 +304,7 @@ After configuring and restarting Claude for Desktop, you can use natural languag
 | `upload-file` | Upload a file to the FTP server (pass `encoding: "base64"` for binary content) |
 | `create-directory` | Create a new directory on the FTP server |
 | `delete-file` | Delete a file from the FTP server |
-| `delete-directory` | Delete a directory from the FTP server |
+| `delete-directory` | Delete a directory on the FTP server |
 | `rename-file` | Rename or move a file or directory on the FTP server |
 | `edit-file` | Replace an exact string in a text file without re-uploading the whole file content |
 | `append-file` | Append content to a file (creates it if missing) |


### PR DESCRIPTION
Adds `CONTRIBUTING.md` with the maintainer workflow for pull requests, version updates, npm publishing, and Smithery publishing.

The release instructions now cover all three version locations used by the project: `package.json`, `manifest.json`, and the `McpServer` version in `src/index.ts`.

The README now points Smithery users to the team-owned listing `alxspikers-team/mcp-server-ftp`, including the badge, listing URL, and install command.

No runtime behavior changed.