### PR TITLE
fix: don't let default SSH keys silently shadow a configured password

### DIFF
--- a/src/sftp-client.ts
+++ b/src/sftp-client.ts
@@ -72,7 +72,11 @@ export class SftpClient {
           );
         }
       }
-    } else {
+    } else if (!this.config.password) {
+      // Only auto-detect a default SSH key when no password was configured
+      // either — otherwise an unrelated local key (e.g. a personal GitHub
+      // key at ~/.ssh/id_rsa) silently shadows an explicitly configured
+      // FTP_PASSWORD and gets tried against a host it has nothing to do with.
       for (const p of DEFAULT_KEY_PATHS) {
         privateKey = resolvePrivateKey(p);
         if (privateKey) break;


### PR DESCRIPTION
## Summary

`SftpClient.loadPrivateKey()` auto-scans `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, and `~/.ssh/id_ecdsa` whenever `FTP_PRIVATE_KEY_PATH` is unset, and uses whatever key it finds there for authentication -- completely ignoring `FTP_PASSWORD` if one is also configured.

In practice this means: any user who has a personal SSH key at one of those default paths (very common -- e.g. a GitHub key) and who configures password-only auth (`FTP_USER`/`FTP_PASSWORD`, no `FTP_PRIVATE_KEY_PATH`) will have that unrelated local key silently tried against the configured SFTP host instead of their password. Auth fails with a generic `All configured authentication methods failed` error from ssh2, which gives no indication that a local SSH key -- not the password -- is the actual culprit. This can burn a lot of debugging time, including re-encrypting/rotating credentials that were never actually the problem.

## Fix

The default-key auto-detection now only runs when **no password is configured either**. An explicit `FTP_PASSWORD` always takes precedence over an auto-detected default key. Explicitly setting `FTP_PRIVATE_KEY_PATH` is unaffected -- that still takes priority over everything, as before.

## Test plan

- [x] `npm run build` succeeds
- [x] Verified against a real SFTP host: with a `~/.ssh/id_rsa` present and `FTP_PASSWORD` configured but no `FTP_PRIVATE_KEY_PATH`, auth now correctly uses the password and connects, instead of trying the unrelated local key and failing
- [ ] Maintainer review of the precedence change (key-only configs with no password still fall back to default key scanning as before)